### PR TITLE
Made the target flag mandatory 

### DIFF
--- a/bhg.py
+++ b/bhg.py
@@ -4,7 +4,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 parser = argparse.ArgumentParser(description='Check headers for target web site.')
-parser.add_argument('-t','--target', dest='target', type=str, help='Target')
+parser.add_argument('-t','--target', dest='target', type=str, help='Target', required=True)
 parser.add_argument('-i','--insecure', dest='verify', action="store_false", default=True, help='Make insecure requests')
 parser.add_argument('-u','--username', dest='username', type=str, required=False, help='Username for HTTP Basic authentication')
 parser.add_argument('-p','--password', dest='password', type=str, required=False, help='Password for HTTP Basic authentication')


### PR DESCRIPTION
The user must supply a target, otherwise
`    print("Getting Headers for: "+args.target+"\n")`

Will try to concatenate a Str and a NoneType, causing it to spit out a cryptic python error. 